### PR TITLE
Consistently use qint64 for session time

### DIFF
--- a/QtWebApp/httpserver/httpserverconfig.cpp
+++ b/QtWebApp/httpserver/httpserverconfig.cpp
@@ -57,7 +57,7 @@ HttpSessionStoreConfig::HttpSessionStoreConfig(QSettings *settings)
 
 void HttpSessionStoreConfig::parseSettings(const QSettings &settings)
 {
-	expirationTime = parseNum(settings.value("expirationTime", (qulonglong)expirationTime), 1000);
+	expirationTime = parseNum(settings.value("expirationTime", expirationTime), 1000);
 	cookieName = settings.value("cookieName", cookieName).toByteArray();
 	
 	cookiePath = settings.value("cookiePath", cookiePath).toByteArray();

--- a/QtWebApp/httpserver/httpserverconfig.h
+++ b/QtWebApp/httpserver/httpserverconfig.h
@@ -75,7 +75,7 @@ public:
 	HttpSessionStoreConfig(QSettings *settings);
 	
 	/// The expiration time of the cookie.
-	quint64 expirationTime = 3600e3;
+	qint64 expirationTime = 3600e3;
 	/// The name of the cookie.
 	QByteArray cookieName = "sessionid";
 	


### PR DESCRIPTION
This fixes a compilation warning about comparing signed/unsigned.