### PR TITLE
Fix clazy warning: signals/slots should be fully qualified

### DIFF
--- a/QtWebApp/httpserver/httpconnectionhandler.h
+++ b/QtWebApp/httpserver/httpconnectionhandler.h
@@ -106,7 +106,7 @@ public slots:
 	  Received from from the listener, when the handler shall start processing a new connection.
 	  @param socketDescriptor references the accepted connection.
 	*/
-	void handleConnection(const tSocketDescriptor socketDescriptor);
+	void handleConnection(const qtwebapp::tSocketDescriptor socketDescriptor);
 	
 private slots:
 	

--- a/QtWebApp/httpserver/httplistener.h
+++ b/QtWebApp/httpserver/httplistener.h
@@ -91,10 +91,9 @@ signals:
 	/**
 	  Sent to the connection handler to process a new incoming connection.
 	  @param socketDescriptor references the accepted connection.
-	*/
-	
-	void handleConnection(tSocketDescriptor socketDescriptor);
-	
+        */
+        void handleConnection(qtwebapp::tSocketDescriptor socketDescriptor);
+
 };
 
 } // end of namespace


### PR DESCRIPTION
QtWebApp/httpserver/httpconnectionhandler.h:108:2:
warning: slot arguments need to be fully-qualified
(qtwebapp::tSocketDescriptor instead of tSocketDescriptor)
[clazy-fully-qualified-moc-types]