### PR TITLE
Fix compilation with clang: %i does not work for quint64

### DIFF
--- a/QtWebApp/httpserver/httpsessionstore.cpp
+++ b/QtWebApp/httpserver/httpsessionstore.cpp
@@ -16,7 +16,7 @@ HttpSessionStore::HttpSessionStore(const HttpSessionStoreConfig &cfg, QObject* p
     connect(&cleanupTimer,SIGNAL(timeout()),this,SLOT(sessionTimerEvent()));
     cleanupTimer.start(60000);
 #ifdef CMAKE_DEBUG
-    qDebug("HttpSessionStore: Sessions expire after %i milliseconds",cfg.expirationTime);
+    qDebug() << "HttpSessionStore: Sessions expire after" << cfg.expirationTime << "milliseconds";
 #endif
 }
 


### PR DESCRIPTION
This allows compiling QtWebApp with clang.
