### PR TITLE
Fix signature of TemplateCache::tryFile

### DIFF
--- a/QtWebApp/templateengine/templatecache.cpp
+++ b/QtWebApp/templateengine/templatecache.cpp
@@ -15,7 +15,7 @@ TemplateCache::TemplateCache(const TemplateEngineConfig &cfg, QObject* parent)
 #endif
 }
 
-QString TemplateCache::tryFile(const QString localizedName)
+QString TemplateCache::tryFile(const QString &localizedName)
 {
     qint64 now=QDateTime::currentMSecsSinceEpoch();
     mutex.lock();

--- a/QtWebApp/templateengine/templatecache.h
+++ b/QtWebApp/templateengine/templatecache.h
@@ -66,7 +66,7 @@ protected:
       @param localizedName Name of the template with locale to find
       @return The template document, or empty string if not found
     */
-    virtual QString tryFile(const QString localizedName);
+    QString tryFile(const QString &localizedName) override;
 
 private:
 


### PR DESCRIPTION
The function should override it's base class' tryFile.
Due to the missing reference it would shadow it instead.