### PR TITLE
Removed alias for tSocketDescriptor

### DIFF
--- a/QtWebApp/httpserver/httpconnectionhandler.cpp
+++ b/QtWebApp/httpserver/httpconnectionhandler.cpp
@@ -81,7 +81,7 @@ void HttpConnectionHandler::createSocket()
 }
 
 
-void HttpConnectionHandler::handleConnection(tSocketDescriptor socketDescriptor)
+void HttpConnectionHandler::handleConnection(qintptr socketDescriptor)
 {
 #ifdef CMAKE_DEBUG
 	qDebug("HttpConnectionHandler (%p): handle new connection", static_cast<void*>(this));

--- a/QtWebApp/httpserver/httpconnectionhandler.h
+++ b/QtWebApp/httpserver/httpconnectionhandler.h
@@ -20,13 +20,6 @@
 
 namespace qtwebapp {
 
-/** Alias type definition, for compatibility to different Qt versions */
-#if QT_VERSION >= 0x050000
-typedef qintptr tSocketDescriptor;
-#else
-typedef int tSocketDescriptor;
-#endif
-
 /** Alias for QSslConfiguration if OpenSSL is not supported */
 #ifdef QT_NO_SSL
 #  define QSslConfiguration QObject
@@ -106,7 +99,7 @@ public slots:
 	  Received from from the listener, when the handler shall start processing a new connection.
 	  @param socketDescriptor references the accepted connection.
 	*/
-	void handleConnection(const tSocketDescriptor socketDescriptor);
+	void handleConnection(qintptr socketDescriptor);
 	
 private slots:
 	

--- a/QtWebApp/httpserver/httplistener.cpp
+++ b/QtWebApp/httpserver/httplistener.cpp
@@ -18,7 +18,7 @@ HttpListener::HttpListener(const HttpServerConfig &cfg, HttpRequestHandler* requ
     pool=nullptr;
     this->requestHandler=requestHandler;
     // Reqister type of socketDescriptor for signal/slot handling
-    qRegisterMetaType<tSocketDescriptor>("tSocketDescriptor");
+    qRegisterMetaType<qintptr>("qintptr");
     // Start listening
     listen();
 }
@@ -61,7 +61,7 @@ void HttpListener::close() {
     }
 }
 
-void HttpListener::incomingConnection(tSocketDescriptor socketDescriptor) {
+void HttpListener::incomingConnection(qintptr socketDescriptor) {
 #ifdef SUPERVERBOSE
     qDebug("HttpListener: New connection");
 #endif
@@ -76,7 +76,7 @@ void HttpListener::incomingConnection(tSocketDescriptor socketDescriptor) {
     if (freeHandler)
     {
         // The descriptor is passed via event queue because the handler lives in another thread
-        QMetaObject::invokeMethod(freeHandler, "handleConnection", Qt::QueuedConnection, Q_ARG(tSocketDescriptor, socketDescriptor));
+        QMetaObject::invokeMethod(freeHandler, "handleConnection", Qt::QueuedConnection, Q_ARG(qintptr, socketDescriptor));
     }
     else
     {

--- a/QtWebApp/httpserver/httplistener.h
+++ b/QtWebApp/httpserver/httplistener.h
@@ -73,7 +73,7 @@ public:
 protected:
 	
 	/** Serves new incoming connection requests */
-	void incomingConnection(tSocketDescriptor socketDescriptor);
+	void incomingConnection(qintptr socketDescriptor);
 	
 private:
 	
@@ -91,10 +91,9 @@ signals:
 	/**
 	  Sent to the connection handler to process a new incoming connection.
 	  @param socketDescriptor references the accepted connection.
-	*/
-	
-	void handleConnection(tSocketDescriptor socketDescriptor);
-	
+        */
+	void handleConnection(qintptr socketDescriptor);
+
 };
 
 } // end of namespace


### PR DESCRIPTION
Removed alias for tSocketDescriptor, which failed for the invokeMethod function. 