### PR TITLE
Build with Qt 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,14 @@ jobs:
             cc: "clang"
             cxx: "clang++"
             linkflags: ""
+          - qt_version: 6.2.0
+            extra_modules: "qt5compat"
     steps:
       - uses: actions/checkout@v2
       - uses: jurplel/install-qt-action@v2
         with:
           version: ${{ matrix.qt_version }}
+          modules: ${{ matrix.extra_modules }}
       
       - name: Build QtWebApp
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,30 +7,35 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.os }} ${{matrix.cxx}} Qt ${{matrix.qt_version}}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04, macos-latest]
+        cxx: ["g++", "clang++"]
+        qt_version: [5.15.2]
+        exclude:
+          - os: macos-latest
+            cxx: "g++"
         include:
-          - name: "Ubuntu 20.04 GCC"
-            os: ubuntu-20.04
+          - os: ubuntu-20.04
             cc: "gcc"
             cxx: "g++"
             linkflags: ""
-          - name: "Ubuntu 20.04 Clang/LLD"
-            os: ubuntu-20.04
+          - os: ubuntu-20.04
             cc: "clang"
             cxx: "clang++"
             linkflags: "-fuse-ld=lld"
-          - name: "MacOS Latest Clang"
-            os: macos-latest
+          - os: macos-latest
             cc: "clang"
             cxx: "clang++"
             linkflags: ""
     steps:
       - uses: actions/checkout@v2
       - uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ matrix.qt_version }}
       
       - name: Build QtWebApp
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest]
         cxx: ["g++", "clang++"]
-        qt_version: [5.15.2]
+        qt_version: [5.15.2, 6.2.0]
         exclude:
           - os: macos-latest
             cxx: "g++"

--- a/Demo1/CMakeLists.txt
+++ b/Demo1/CMakeLists.txt
@@ -3,7 +3,6 @@ project("QtWebApp Demo 1")
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Network)
 find_package(QtWebApp REQUIRED COMPONENTS HttpServer Logging TemplateEngine)
 
 add_executable(demo1

--- a/Demo2/CMakeLists.txt
+++ b/Demo2/CMakeLists.txt
@@ -3,7 +3,6 @@ project("QtWebApp Demo 2")
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Network)
 find_package(QtWebApp REQUIRED COMPONENTS HttpServer Logging)
 
 add_executable(demo2

--- a/QtWebApp/CMakeLists.txt
+++ b/QtWebApp/CMakeLists.txt
@@ -9,6 +9,10 @@ set(qtwebapp_VERSION ${qtwebapp_MAJOR}.${qtwebapp_MINOR}.${qtwebapp_PATCH})
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED HINTS $ENV{Qt6_DIR} $ENV{Qt5_DIR})
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Network REQUIRED)
 
+if (Qt6_FOUND)
+    find_package(Qt6 COMPONENTS Core5Compat REQUIRED)
+endif()
+
 set(CMAKE_AUTOMOC ON)
 
 add_definitions(-DQTWEBAPPLIB_EXPORT)

--- a/QtWebApp/CMakeLists.txt
+++ b/QtWebApp/CMakeLists.txt
@@ -6,7 +6,8 @@ set(qtwebapp_MINOR 8)
 set(qtwebapp_PATCH 3)
 set(qtwebapp_VERSION ${qtwebapp_MAJOR}.${qtwebapp_MINOR}.${qtwebapp_PATCH})
 
-find_package(Qt5 REQUIRED COMPONENTS Core Network)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED HINTS $ENV{Qt6_DIR} $ENV{Qt5_DIR})
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Network REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 
@@ -45,7 +46,7 @@ target_include_directories(QtWebAppGlobal PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 	$<INSTALL_INTERFACE:include/qtwebapp>
 )
-target_link_libraries(QtWebAppGlobal Qt5::Core)
+target_link_libraries(QtWebAppGlobal Qt${QT_VERSION_MAJOR}::Core)
 set_target_properties(QtWebAppGlobal PROPERTIES
 		VERSION ${qtwebapp_VERSION}
 		SOVERSION ${qtwebapp_MAJOR}

--- a/QtWebApp/cmake/QtWebAppConfig.cmake.in
+++ b/QtWebApp/cmake/QtWebAppConfig.cmake.in
@@ -13,15 +13,15 @@ if (QtWebApp_FIND_REQUIRED)
 	set(_req REQUIRED)
 endif()
 
-# TODO: Qt5Network is not required for all modules
-find_package(Qt5 ${_req} COMPONENTS Core Network)
-if (NOT ${Qt5_FOUND})
-	set(QtWebApp_NOT_FOUND_MESSAGE "Unable to find Qt5")
+# TODO: Qt Network is not required for all modules
+find_package(Qt@QT_VERSION_MAJOR@ ${_req} COMPONENTS Core Network)
+if (NOT ${Qt@QT_VERSION_MAJOR@_FOUND})
+	set(QtWebApp_NOT_FOUND_MESSAGE "Unable to find Qt@QT_VERSION_MAJOR@")
 	set(QtWebApp_FOUND False)
 	return()
 endif()
 
-set(QtWebApp_LIBRARIES Qt5::Core Qt5::Network)
+set(QtWebApp_LIBRARIES Qt@QT_VERSION_MAJOR@::Core Qt@QT_VERSION_MAJOR@::Network)
 
 set(_comps Global ${QtWebApp_FIND_COMPONENTS})
 

--- a/QtWebApp/cmake/QtWebAppConfig.cmake.in
+++ b/QtWebApp/cmake/QtWebAppConfig.cmake.in
@@ -20,6 +20,9 @@ if (NOT ${Qt@QT_VERSION_MAJOR@_FOUND})
 	set(QtWebApp_FOUND False)
 	return()
 endif()
+if (@QT_VERSION_MAJOR@ EQUAL 6)
+	find_package(Qt6 COMPONENTS Core5Compat REQUIRED)
+endif()
 
 set(QtWebApp_LIBRARIES Qt@QT_VERSION_MAJOR@::Core Qt@QT_VERSION_MAJOR@::Network)
 

--- a/QtWebApp/httpserver/CMakeLists.txt
+++ b/QtWebApp/httpserver/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(QtWebAppHttpServer PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 	$<INSTALL_INTERFACE:include/qtwebapp/httpserver>
 )
-target_link_libraries(QtWebAppHttpServer QtWebAppGlobal Qt5::Core Qt5::Network)
+target_link_libraries(QtWebAppHttpServer QtWebAppGlobal Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network)
 set_target_properties(QtWebAppHttpServer PROPERTIES
 		VERSION ${qtwebapp_VERSION}
 		SOVERSION ${qtwebapp_MAJOR}

--- a/QtWebApp/logging/CMakeLists.txt
+++ b/QtWebApp/logging/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(QtWebAppLogging PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 	$<INSTALL_INTERFACE:include/qtwebapp/logging>
 )
-target_link_libraries(QtWebAppLogging Qt5::Core Qt5::Network)
+target_link_libraries(QtWebAppLogging Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network)
 set_target_properties(QtWebAppLogging PROPERTIES
 		VERSION ${qtwebapp_VERSION}
 		SOVERSION ${qtwebapp_MAJOR}

--- a/QtWebApp/templateengine/CMakeLists.txt
+++ b/QtWebApp/templateengine/CMakeLists.txt
@@ -17,6 +17,9 @@ target_include_directories(QtWebAppTemplateEngine PUBLIC
 	$<INSTALL_INTERFACE:include/qtwebapp/templateengine>
 )
 target_link_libraries(QtWebAppTemplateEngine QtWebAppGlobal Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network)
+if (Qt6_FOUND)
+    target_link_libraries(QtWebAppTemplateEngine Qt6::Core5Compat)
+endif()
 set_target_properties(QtWebAppTemplateEngine PROPERTIES
 		VERSION ${qtwebapp_VERSION}
 		SOVERSION ${qtwebapp_MAJOR}

--- a/QtWebApp/templateengine/CMakeLists.txt
+++ b/QtWebApp/templateengine/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(QtWebAppTemplateEngine PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 	$<INSTALL_INTERFACE:include/qtwebapp/templateengine>
 )
-target_link_libraries(QtWebAppTemplateEngine QtWebAppGlobal Qt5::Core Qt5::Network)
+target_link_libraries(QtWebAppTemplateEngine QtWebAppGlobal Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network)
 set_target_properties(QtWebAppTemplateEngine PROPERTIES
 		VERSION ${qtwebapp_VERSION}
 		SOVERSION ${qtwebapp_MAJOR}


### PR DESCRIPTION
This is porting the CMake bits, most of the boring work is already in. For now QtWebApp depends on the Qt5Compat module, for QTextCodec, it would be nice to get rid of that or make it optional, but at least it should be usable now. I don't quite know how important text codec support really is, I'd expect utf-8 to be used almost everywhere nowadays.